### PR TITLE
Amazon Linux 2 AMI support

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -17,5 +17,6 @@ fah_pkgs:
     - 'https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.5/fahclient_7.5.1_amd64.deb'
 #    - 'https://download.foldingathome.org/releases/public/release/fahcontrol/debian-stable-64bit/v7.5/fahcontrol_7.5.1-1_all.deb'
 #    - 'https://download.foldingathome.org/releases/public/release/fahviewer/debian-stable-64bit/v7.5/fahviewer_7.5.1_amd64.deb'
-
+  Amazon:
+    - 'https://download.foldingathome.org/releases/public/release/fahclient/centos-6.7-64bit/v7.5/fahclient-7.5.1-1.x86_64.rpm'
 ...

--- a/inventory
+++ b/inventory
@@ -10,3 +10,12 @@ cpass='password'
 username='anonymous'
 passkey=''
 team='0'
+
+# Variables below can be used with AWS instances
+#ansible_ssh_private_key_file=
+#ansible_connection=ssh
+#ansible_user=ec2-user
+#ansible_become=yes
+#ansible_become_method=sudo
+#ansible_become_user=root
+

--- a/main.yml
+++ b/main.yml
@@ -23,6 +23,19 @@
       state: present
     when: "ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora'"
 
+# Amazon linux doesn't have compat-openssl10 or something similar
+# It doesn't appear that the fahclient actually needs it
+  - name: install required packages (RPM)
+    package:
+      name:
+        - freeglut
+        - libcanberra-gtk2
+        - make
+        - mesa-libGLU
+        - pygtk2
+        - python2
+      state: present
+    when: "ansible_distribution == 'Amazon'"
 
   - name: Gather package facts
     package_facts:
@@ -38,7 +51,7 @@
   - name: install FaH packages (RPM)
     command: "rpm -ivh --nodeps /tmp/{{ item | regex_replace( '.*fah', 'fah' ) }}"
     with_items: "{{ fah_pkgs[ ansible_distribution ] }}"
-    when: "'fahclient' not in ansible_facts.packages and ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora'"
+    when: "'fahclient' not in ansible_facts.packages and ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora' or ansible_distribution == 'Amazon'"
 
   - name: install FaH packages (DEB)
     apt:


### PR DESCRIPTION
Add support for Amazon Linux 2 AMIs. There doesn't appear to be a compat-openssl10 package for Amazon Linux 2. The fahclient also runs fine without it. I've tested to ensure that it can pull jobs, run them to completion, and submit them back to the servers to ensure there isn't some place where that openssl10 library is used during that process.