### PR TITLE
Disable rpm post scripts for fahclient

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -49,7 +49,7 @@
     when: "'fahclient' not in ansible_facts.packages"
 
   - name: install FaH packages (RPM)
-    command: "rpm -ivh --nodeps /tmp/{{ item | regex_replace( '.*fah', 'fah' ) }}"
+    command: "rpm -ivh --nodeps --noscripts /tmp/{{ item | regex_replace( '.*fah', 'fah' ) }}"
     with_items: "{{ fah_pkgs[ ansible_distribution ] }}"
     when: "'fahclient' not in ansible_facts.packages and ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora' or ansible_distribution == 'Amazon'"
 
@@ -62,10 +62,41 @@
     with_items: "{{ fah_pkgs[ ansible_distribution ] }}"
     when: "'fahclient' not in ansible_facts.packages and ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'"
 
+  - name: Ensure group "somegroup" exists
+    group:
+      name: fahclient
+      state: present
+      system: yes
+    when: "'fahclient' not in ansible_facts.packages and ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora' or ansible_distribution == 'Amazon'"
+
+  - name: Create fahclient user
+    user:
+      name: fahclient
+      state: present
+      group: fahclient
+      comment: "Folding@home Client"
+      shell: /sbin/nologin
+      expires: -1
+      system: yes
+    when: "'fahclient' not in ansible_facts.packages and ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora' or ansible_distribution == 'Amazon'"
+
+  - name: Create fahclient directories
+    file:
+      path: "{{ item }}"
+      state: directory
+      owner: fahclient
+      group: fahclient
+      mode: 0775
+    with_items:
+      - /var/lib/fahclient
+      - /etc/fahclient
+    when: "'fahclient' not in ansible_facts.packages and ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora' or ansible_distribution == 'Amazon'"
+
   - name: Stop FaH client
     service:
       name: FAHClient
       state: stopped
+    when: "'fahclient' not in ansible_facts.packages and ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'"
 
   - name: Wait for termination of all FaH client processes
     wait_for:

--- a/main.yml
+++ b/main.yml
@@ -1,5 +1,6 @@
+---
 - hosts: servers
-  become: yes
+  become: true
 
   tasks:
 
@@ -15,7 +16,7 @@
       name:
         - compat-openssl10
         - freeglut
-        - libcanberra-gtk2 
+        - libcanberra-gtk2
         - make
         - mesa-libGLU
         - pygtk2
@@ -66,7 +67,7 @@
     group:
       name: fahclient
       state: present
-      system: yes
+      system: true
     when: "'fahclient' not in ansible_facts.packages and ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora' or ansible_distribution == 'Amazon'"
 
   - name: Create fahclient user
@@ -77,7 +78,7 @@
       comment: "Folding@home Client"
       shell: /sbin/nologin
       expires: -1
-      system: yes
+      system: true
     when: "'fahclient' not in ansible_facts.packages and ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora' or ansible_distribution == 'Amazon'"
 
   - name: Create fahclient directories
@@ -115,7 +116,7 @@
 
   - name: Copy default init script to docs directory
     copy:
-      remote_src: yes
+      remote_src: true
       src: /etc/init.d/FAHClient
       dest: /usr/share/doc/fahclient/FAHClient.init
     when: initscript.stat.exists
@@ -128,13 +129,13 @@
   - name: Install FaH systemd service file
     copy:
       src: FAHClient.service
-      dest:  /etc/systemd/system/FAHClient.service
+      dest: /etc/systemd/system/FAHClient.service
 
   - name: Open firewalld port
     firewalld:
-      immediate: yes
+      immediate: true
       port: '36330/tcp'
-      permanent: yes
+      permanent: true
       state: enabled
     when: "ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora'"
 
@@ -148,8 +149,8 @@
   - name: Start and enable FaH client
     service:
       name: FAHClient
-      daemon_reload: yes
-      enabled: yes
+      daemon_reload: true
+      enabled: true
       state: started
 
 ...


### PR DESCRIPTION
The RPM post scripts for the FAH Client install the init scripts along with creating the fahclient user and directories. The init script needs to be stopped in order to update the config.xml. Often the FAHClient processes will not stop even when the service stop request has been issued. This causes the playbook to wait for an extended period of time and/or exit because the processes do not stop. By disabling the RPM post script and adding the user/group/directories in the playbook this issue can be avoided.

Also made a couple of minor updates with the help of yamllint.