### PR TITLE
Add check for firewalld service before configuring the service

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -4,6 +4,9 @@
 
   tasks:
 
+  - name: Populate service facts
+    service_facts:
+
 #  - name: install required packages (DEB)
 #    package:
 #      name:
@@ -137,7 +140,7 @@
       port: '36330/tcp'
       permanent: true
       state: enabled
-    when: "ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora'"
+    when: "(ansible_distribution == 'RedHat' or ansible_distribution == 'Fedora') and 'firewalld' in services"
 
   - name: Open UFW port
     ufw:


### PR DESCRIPTION
Add check for firewalld service before configuring the service. The default RHEL 8.1