### PR TITLE
adding systemd stop for Redhat/Fedora, added new versions from F@H

### DIFF
--- a/roles/fahclient/tasks/service.yaml
+++ b/roles/fahclient/tasks/service.yaml
@@ -2,11 +2,17 @@
 
 # Client isn't running on RHEL/Centos/Fedora/Amazon hosts
 # because it is installed with --noscripts
-- name: Stop FaH client
+- name: Stop FaH client (init)
   service:
     name: FAHClient
     state: stopped
   when: "ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'"
+
+- name: Stop F@H client (systemd)
+  systemd: 
+    name: FAHClient.service
+    state: stopped
+  when: "ansible_distribution == 'Fedora' or ansible_distribution == 'RedHat'"
 
 - name: Wait for termination of all FaH client processes
   wait_for:

--- a/roles/fahclient/vars/main.yaml
+++ b/roles/fahclient/vars/main.yaml
@@ -20,6 +20,12 @@ fah_client_pkgs:
     '7.5.1': 'https://download.foldingathome.org/releases/public/release/fahclient/centos-6.7-64bit/v7.5/fahclient-7.5.1-1.x86_64.rpm'
     '7.6.1': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/fahclient-7.6.1-1.x86_64.rpm'
     '7.6.2': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/fahclient-7.6.2-1.x86_64.rpm'
+    '7.6.3': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/fahclient-7.6.3-1.x86_64.rpm'
+    '7.6.4': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/fahclient-7.6.4-1.x86_64.rpm'
+    '7.6.5': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/fahclient-7.6.5-1.x86_64.rpm'
+    '7.6.6': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/fahclient-7.6.6-1.x86_64.rpm'
+    'latest': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/latest.rpm'
+
   RedHat:
     '7.4.15': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.4/fahclient-7.4.15-1.x86_64.rpm'
     '7.4.16': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.4/fahclient-7.4.16-1.x86_64.rpm'
@@ -29,6 +35,12 @@ fah_client_pkgs:
     '7.5.1': 'https://download.foldingathome.org/releases/public/release/fahclient/centos-6.7-64bit/v7.5/fahclient-7.5.1-1.x86_64.rpm'
     '7.6.1': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/fahclient-7.6.1-1.x86_64.rpm'
     '7.6.2': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/fahclient-7.6.2-1.x86_64.rpm'
+    '7.6.3': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/fahclient-7.6.3-1.x86_64.rpm'
+    '7.6.4': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/fahclient-7.6.4-1.x86_64.rpm'
+    '7.6.5': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/fahclient-7.6.5-1.x86_64.rpm'
+    '7.6.6': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/fahclient-7.6.6-1.x86_64.rpm'
+    'latest': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.6/latest.rpm'
+
   CentOS:
     '7.4.15': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.4/fahclient-7.4.15-1.x86_64.rpm'
     '7.4.16': 'https://download.foldingathome.org/releases/beta/release/fahclient/centos-6.7-64bit/v7.4/fahclient-7.4.16-1.x86_64.rpm'

--- a/roles/fahcontroller/vars/main.yaml
+++ b/roles/fahcontroller/vars/main.yaml
@@ -12,6 +12,7 @@ fah_control_pkgs:
    '7.6.1': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/debian-stable-64bit/v7.6/fahcontrol_7.6.1-1_all.deb'
    '7.6.2': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/debian-stable-64bit/v7.6/fahcontrol_7.6.2-1_all.deb'
    '7.6.3': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/debian-stable-64bit/v7.6/fahcontrol_7.6.3-1_all.deb'
+
   Fedora:
     '7.4.11': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.4/fahcontrol-7.4.11-1.noarch.rpm'
     '7.4.15': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.4/fahcontrol-7.4.15-1.noarch.rpm'
@@ -23,6 +24,11 @@ fah_control_pkgs:
     '7.6.1': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/fahcontrol-7.6.1-1.noarch.rpm'
     '7.6.2': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/fahcontrol-7.6.2-1.noarch.rpm'
     '7.6.3': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/fahcontrol-7.6.3-1.noarch.rpm'
+    '7.6.4': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/fahcontrol-7.6.4-1.noarch.rpm'
+    '7.6.5': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/fahcontrol-7.6.5-1.noarch.rpm'
+    '7.6.6': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/fahcontrol-7.6.6-1.noarch.rpm'
+    'latest': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/latest.rpm'
+
   RedHat:
     '7.4.11': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.4/fahcontrol-7.4.11-1.noarch.rpm'
     '7.4.15': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.4/fahcontrol-7.4.15-1.noarch.rpm'
@@ -34,6 +40,11 @@ fah_control_pkgs:
     '7.6.1': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/fahcontrol-7.6.1-1.noarch.rpm'
     '7.6.2': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/fahcontrol-7.6.2-1.noarch.rpm'
     '7.6.3': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/fahcontrol-7.6.3-1.noarch.rpm'
+    '7.6.4': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/fahcontrol-7.6.4-1.noarch.rpm'
+    '7.6.5': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/fahcontrol-7.6.5-1.noarch.rpm'
+    '7.6.6': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/fahcontrol-7.6.6-1.noarch.rpm'
+    'latest': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.6/latest.rpm'
+
   CentOS:
     '7.4.11': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.4/fahcontrol-7.4.11-1.noarch.rpm'
     '7.4.15': 'https://download.foldingathome.org/releases/beta/release/fahcontrol/centos-6.7-64bit/v7.4/fahcontrol-7.4.15-1.noarch.rpm'


### PR DESCRIPTION
Updated the fahclient that froze on the "waiting for fahclient stop" and assumed that Redhat and Fedora will be having Systemd control it. also added newer version as well as latest to the RPMS from Folding@home source.